### PR TITLE
Ttg/featured modal tos

### DIFF
--- a/edx-platform/nau-basic/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/edx-platform/nau-basic/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -1348,3 +1348,5 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
+#~ msgid "All rights reserved."
+#~ msgstr "Todos os direitos reservados."

--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_extras.scss
@@ -3,4 +3,5 @@
 @import 'footer';
 @import 'responsive';
 @import 'forms';
-@import 'courses';
+@import 'courses'; 
+@import 'modal';

--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_modal.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_modal.scss
@@ -1,0 +1,38 @@
+.modal-container {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: none;
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  max-width: 500px;
+  border-radius: 10px;
+  text-align: center;
+  box-shadow: -7px 8px 20px 2px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+button.button-modal {
+  border-radius: 10px;
+  margin-top: 15px;
+  width: 200px;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: #0066a2;
+    box-shadow: none;
+  }
+}

--- a/edx-platform/nau-basic/lms/templates/footer.html
+++ b/edx-platform/nau-basic/lms/templates/footer.html
@@ -6,9 +6,17 @@
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
+  from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <% footer = get_footer(is_secure=is_secure) %>
 <%namespace name='static' file='static_content.html'/>
+<%
+options_modal = configuration_helpers.get_value("MODAL_TOS", {})
+modal_force_display = options_modal.get("modal_force_display", False)
+name_preference_tos = options_modal.get("modal_tos_name_preference", "")
+modal_tos_text = options_modal.get('modal_tos_text', "We have updated our terms of service")
+%>
 <%
     www_pt = static.get_value('NAU_MARKETING_BASE_HREF', {}).get("pt-pt", "")
     www_en = static.get_value('NAU_MARKETING_BASE_HREF', {}).get("en", "")
@@ -105,3 +113,91 @@
     <link rel="stylesheet" type="text/css" href="${url}"></link>
   % endfor
 % endif
+
+%if modal_force_display:
+## Pop-up tos
+<div class="modal-container">
+  <div class="modal-content">
+    % if modal_tos_text:
+    ${modal_tos_text | n}
+    <script type="text/javascript">
+    
+    </script>
+
+    % endif
+    <button class="button-modal btn-primary">Accept</button>
+  </div>
+</div>
+
+  %if user.is_authenticated:
+  <% value_preference = get_user_preference(user, name_preference_tos) %>
+
+  <script type="text/javascript">
+
+    const newTosModal = (function () {
+      const valuePreference = '${value_preference}';
+      const urlPreferenceTos = '/api/user/v1/preferences/${user}/${name_preference_tos}';
+      const namePreferenceTos ='${name_preference_tos}';
+      const dateJoined ='${user.date_joined}';
+      const removeWord = namePreferenceTos.slice(-10).replaceAll('_', '-') 
+      const getDateJoined = new Date(dateJoined);
+      const getDateModalTos = new Date(removeWord);
+      
+      function userJoinedAfterTosDate() {
+        const valueCompareDates = getDateJoined.getTime() >= getDateModalTos.getTime();
+        let valueCompare;
+        if (valueCompareDates) {
+            valueCompare = true;
+        } else {
+            valueCompare = false;
+        }
+        return valueCompare;
+      }
+
+      function displayModal() {
+        $('.modal-container').css('display', 'block');
+      }
+
+      function hideModal() {
+        $('.modal-container').css('display', 'none');
+      }
+
+      function updatePreference() {
+        $.ajax({
+          url: urlPreferenceTos,
+          type: 'PUT',
+          dataType:'json',
+          contentType: "application/json",
+          data:"true"
+        });
+      }
+      
+      function getPreference() {  
+        if (userJoinedAfterTosDate() || valuePreference == 'True'){
+            hideModal()
+        } else {
+          displayModal()
+        }   
+        events();
+      }
+
+      function events() {
+        $('.button-modal').on('click', function(){
+          hideModal();
+          updatePreference();
+        });
+      }
+
+      return {
+        getPreference: getPreference
+      }
+    })();
+
+    $(window).load (function (){
+      newTosModal.getPreference();
+    });
+
+  </script>
+  %endif
+%endif
+    


### PR DESCRIPTION
**Modal to accept new tos**

In this PR a modal component was created to accept new TOS. The logic of this modal was added to the footer template. This component is displayed in the control panel and cannot continue until new TOS are accepted. It is saved in a new variable in the user preferences, so it is not necessary to accept it when the user logs in again.The modal allows old users to know the updated terms and conditions of the platform.

Modal text can be changed from site configuration.

"MODAL_TOS":{
    "modal_force_display":true,
    "modal_tos_name_preference":"update_tos_2021_06_01",
    "modal_tos_text":"**<h2>We have updated our <a href="https://www.nau.edu.pt/sobre/tos-privacidade-honra/">terms of service</a>. We recommend that you review them carefully. If you continue to use the main Nau site, you do so under the new terms.</h2>"**
}
In case there is a new update, the name of the modal preference should be changed and it should go like the example. The only thing that should be changed is the date

    "modal_tos_name_preference":"update_tos_2021_07_25",


@felipemontoya, @jignaciopm, @MoisesGSalas, @andrey-canon, @mariajgrimaldi, @magajh

![modal-tos](https://user-images.githubusercontent.com/66017940/120549727-8f91df80-c3b9-11eb-8c67-26af3b5418af.png)

