### PR TITLE
Extra courses list as _dashboard_course_listing

### DIFF
--- a/edx-platform/nau-basic/lms/templates/dashboard.html
+++ b/edx-platform/nau-basic/lms/templates/dashboard.html
@@ -313,6 +313,51 @@ from common.djangoapps.student.models import CourseEnrollment
         % endif
       </div>
     </div>
+
+    % if len(plugins["nau_openedx_extensions"]["other_sites_enrollments"]) > 0:
+      <div class="dashboard" id="dashboard-secondary">
+        <div class="main-container">
+          <div class="my-courses" id="network-courses">
+              <header class="wrapper-header-courses">
+                <h2 class="header-courses">${_("Courses from other sites")}</h2>
+              </header>
+
+              <ul class="listing-courses">
+              % for dashboard_index, enrollment in enumerate(plugins["nau_openedx_extensions"]["other_sites_enrollments"]):
+                <%
+                  # Check if the course run is an entitlement and if it has an associated session
+                  entitlement = enrollment if isinstance(enrollment, CourseEntitlement) else None
+                  entitlement_session = entitlement.enrollment_course_run if entitlement else None
+                  entitlement_days_until_expiration = entitlement.get_days_until_expiration() if entitlement else None
+                  entitlement_expiration = datetime.now(tz=pytz.UTC) + timedelta(days=entitlement_days_until_expiration) if (entitlement and entitlement_days_until_expiration < settings.ENTITLEMENT_EXPIRED_ALERT_PERIOD) else None
+                  entitlement_expiration_date = strftime_localized(entitlement_expiration, 'SHORT_DATE') if entitlement and entitlement_expiration else None
+                  entitlement_expired_at = strftime_localized(entitlement.expired_at_datetime, 'SHORT_DATE') if entitlement and entitlement.expired_at_datetime else None
+
+                  is_fulfilled_entitlement = True if entitlement and entitlement_session else False
+                  is_unfulfilled_entitlement = True if entitlement and not entitlement_session else False
+
+                  entitlement_available_sessions = []
+                  show_email_settings = (enrollment.course_id in show_email_settings_for)
+                  course_overview = CourseOverview.get_from_id(enrollment.course_id)
+
+                  session_id = enrollment.course_id
+                  show_courseware_link = show_courseware_links_for.get(session_id, True)
+                  cert_status = cert_statuses.get(session_id)
+                  partner_managed_enrollment = enrollment.mode == 'masters'
+                  credit_status = credit_statuses.get(session_id)
+                  course_mode_info = all_course_modes.get(session_id)
+                  course_verification_status = verification_status_by_course.get(session_id, {})
+                  course_requirements = courses_requirements_not_met.get(session_id)
+                  resume_button_url = resume_button_urls[dashboard_index]
+                %>
+                <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=False, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=False, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=False' />
+              % endfor
+              </ul>
+          </div>
+        </div>
+      </div>
+    % endif
+
 </main>
 
 <div id="email-settings-modal" class="modal" aria-hidden="true">


### PR DESCRIPTION
This PR connects the necessary templates for the extra list of courses to be rendered by re-using the _dashboard_course_listing already available.

All the code from the entilements must remain in the logic.