### PR TITLE
feat: default footer menu links from settings

### DIFF
--- a/edx-platform/nau-basic/lms/templates/footer.html
+++ b/edx-platform/nau-basic/lms/templates/footer.html
@@ -13,8 +13,8 @@
 <%
     www_pt = static.get_value('NAU_MARKETING_BASE_HREF', {}).get("pt-pt", "")
     www_en = static.get_value('NAU_MARKETING_BASE_HREF', {}).get("en", "")
-    footer_menu = static.get_value('NAU_FOOTER_MENU', {}).get(LANGUAGE_CODE, {})
-    nau_social_media = static.get_value('NAU_SOCIAL_MEDIA', [])
+    footer_menu = static.get_value('NAU_FOOTER_MENU', getattr(settings, 'NAU_FOOTER_MENU', {})).get(LANGUAGE_CODE, {})
+    nau_social_media = static.get_value('NAU_SOCIAL_MEDIA', getattr(settings, 'NAU_FOOTER_MENU', []))
 %>
 <footer>
   <section id="footer-nav">


### PR DESCRIPTION
Allow to read `NAU_FOOTER_MENU` setting from settings or from site configuration. This change allows that the footer menu links could be configured only once on Open edX LMS settings by default for all sites.

GN-1178