### PR TITLE
fix: ecommerce compress assets

### DIFF
--- a/ecommerce/nau/templates/force_translations.html
+++ b/ecommerce/nau/templates/force_translations.html
@@ -26,7 +26,7 @@
 
 ## Translators: Original on: ecommerce/templates/oscar/communication/emails/commtype_order_with_csv_body.html:26
 ## Translators: Original on: ecommerce/templates/oscar/communication/emails/commtype_order_with_csv_body.txt:6
-{% trans 'Thank you for purchasing access to %(course_name)s. Let's get your group ready to learn with edX:' %}
+{% trans "Thank you for purchasing access to %(course_name). Let's get your group ready to learn with edX:" %}
 
 ## Translators: Original on: ecommerce/templates/oscar/communication/emails/commtype_order_with_csv_body.html:36
 ## Translators: Original on: ecommerce/templates/oscar/communication/emails/commtype_order_with_csv_body.txt:11


### PR DESCRIPTION
The ecommerce compress of the static assets were failing. causes fccn/nau-tutor-configs#22