### PR TITLE
fix: logo_url not in email

### DIFF
--- a/ecommerce/nau/templates/oscar/customer/email_base.html
+++ b/ecommerce/nau/templates/oscar/customer/email_base.html
@@ -168,12 +168,6 @@
         <td align="center" valign="top">
             <!-- 600px container (white background) -->
             <table class="cn-container">
-                <tr>
-                    <td style="padding-left:30px; padding-right:30px" align="left">
-                        <br>
-                        <img alt="{{ platform_name }} logo" src="{{ logo_url }}" width="100">
-                    </td>
-                </tr>
                 {% block body %}
                 {% endblock body %}
                 {% block footer %}


### PR DESCRIPTION
The logo_url variable isn't available on email templates. fccn/nau-technical#103