### PR TITLE
Fix acessibility in content module links and timed exams

### DIFF
--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_overrides.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_overrides.scss
@@ -783,6 +783,20 @@ article.course>section.details>div.wrapper-course-details>div.course-info>span.i
     border: 2px solid $header-bar-color !important;
 }
 
+.xmodule_display.xmodule_HtmlBlock a {
+    &:link,
+    &:visited,
+    &:active,
+    &:focus {
+        text-decoration: underline;
+    }
+
+    &:hover,
+    &:focus {
+        color: $primary-hover !important;
+    }
+}
+
 .view-profile .wrapper-profile {
     background: none;
 }
@@ -795,4 +809,16 @@ article.course>section.details>div.wrapper-course-details>div.course-info>span.i
 // fix horizontal scroll on course page
 .course-outline .block-tree .section {
     margin-right: 0px;
+}
+
+.course-wrapper .course-content div.timed-exam button.gated-sequence,
+.course-wrapper .course-content div.proctored-exam button.gated-sequence,
+.course-wrapper .courseware-results-wrapper div.timed-exam button.gated-sequence, 
+.course-wrapper .courseware-results-wrapper div.proctored-exam button.gated-sequence {
+    text-align: center !important;
+
+    a {
+        color: white;
+        text-shadow: none !important;
+    }
 }

--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_variables.scss
@@ -3,6 +3,7 @@
 
 // Make a new primary color
 $primary: #074CE1;
+$primary-hover: #0640bf;
 //$blue-pr: #074CE1;
 // Primary blue
 $blue: $primary;


### PR DESCRIPTION
This PR solves some issues with the link styles on the module. The link color was not sufficient for color blind users.
As for timed exams, the start button was incorrectly formated.

![image](https://github.com/fccn/nau-themes/assets/34194007/5c2cc0d0-4411-409f-b545-5c2fb5a1cc71)

The two issues were fixed:
* Place a text underline on links that are created in the content area. 
* Fix the styling of the start button on timed exams.

The timed exam start button is now displayed correctly:
![image](https://github.com/fccn/nau-themes/assets/34194007/52ebd46f-186c-4cd4-bb06-9814096851cb)

Related with https://github.com/fccn/edx-platform/issues/16
https://github.com/fccn/nau-themes/issues/46