### PR TITLE
fix(lms): overflow problem on footer logos

### DIFF
--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_footer.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_footer.scss
@@ -97,6 +97,8 @@ footer {
 
         .entities-quick-links__line {
             display:flex;
+            flex-direction: row;
+            flex-wrap: wrap;
             justify-content: center;
             gap: 1.5rem;
             border-block-end: 1px solid #dedede;


### PR DESCRIPTION
The footer logos was overflowing when they were too wide.

fccn/nau-technical#338

Change from:
![image](https://github.com/user-attachments/assets/af978942-df58-419c-8c17-63d88d7efdcd)

To:
![image](https://github.com/user-attachments/assets/ebb2e2d8-c83e-4bb6-bc34-178e07e4beb5)
