### PR TITLE
fix(lms): overflow problem on footer logos - Nutmeg

### DIFF
--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_footer.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_footer.scss
@@ -97,6 +97,8 @@ footer {
 
         .entities-quick-links__line {
             display:flex;
+            flex-direction: row;
+            flex-wrap: wrap;
             justify-content: center;
             gap: 1.5rem;
             border-block-end: 1px solid #dedede;


### PR DESCRIPTION
The footer logos was overflowing when they were too wide.

fccn/nau-technical#338

Same as PR: https://github.com/fccn/nau-themes/pull/55 but for Nutmeg