### PR TITLE
fix: not load GTM inside xblock iframe

### DIFF
--- a/edx-platform/nau-basic/lms/templates/head-extra.html
+++ b/edx-platform/nau-basic/lms/templates/head-extra.html
@@ -6,7 +6,7 @@ from lms.djangoapps.ccx.overrides import get_current_ccx
 %>
 
 <% nau_gtm_tracking_id = static.get_value('NAU_GOOGLE_TAG_MANAGER_ID', getattr(settings, 'NAU_GOOGLE_TAG_MANAGER_ID', None)) %>
-% if nau_gtm_tracking_id:
+% if nau_gtm_tracking_id and not disable_header:
   <% nau_gtm_tracking_environment = static.get_value('NAU_GOOGLE_TAG_MANAGER_ENVIRONMENT', getattr(settings, 'NAU_GOOGLE_TAG_MANAGER_ENVIRONMENT', '')) %>
   <!-- Google Tag Manager -->
   % if course:


### PR DESCRIPTION
The Google Tag Manager shouldn't be loaded on embed screens like: xblock and lti iframes.

fccn/nau-technical#347