### PR TITLE
DRAFT: added Gamification header links

### DIFF
--- a/edx-platform/nau-basic/cms/templates/widgets/user_dropdown.html
+++ b/edx-platform/nau-basic/cms/templates/widgets/user_dropdown.html
@@ -1,0 +1,39 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+  from django.conf import settings
+  from django.urls import reverse
+  from django.utils.translation import gettext as _
+  from edx_django_utils.monitoring import set_custom_attribute
+  from common.djangoapps.student.roles import GlobalStaff
+%>
+
+<h3 class="title">
+  <span class="label">
+    <span class="label-prefix sr-only">${_("Currently signed in as:")}</span>
+    <span class="account-username" title="${ user.username }">${ user.username }</span>
+  </span>
+  <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span>
+</h3>
+<div class="wrapper wrapper-nav-sub">
+  <div class="nav-sub">
+    <ul>
+      <li class="nav-item nav-account-dashboard">
+        <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
+      </li>
+      % if GlobalStaff().has_user(user):
+        <li class="nav-item">
+          <a href="${reverse('maintenance:maintenance_index')}">${_("Maintenance")}</a>
+        </li>
+        % if hasattr(settings, 'GAMMA_SETTINGS_URL') and settings.GAMMA_SETTINGS_URL:
+          <li class="nav-item">
+            <a href="${settings.GAMMA_SETTINGS_URL}">${_("Gamification Settings")}</a>
+          </li>
+        % endif
+      % endif
+      <li class="nav-item nav-account-signout">
+        <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/edx-platform/nau-basic/lms/templates/header/user_dropdown.html
+++ b/edx-platform/nau-basic/lms/templates/header/user_dropdown.html
@@ -24,6 +24,7 @@ displayname = get_enterprise_learner_generic_name(request) or username
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
 should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+show_gamification = settings.FEATURES.get('RG_GAMIFICATION', {}).get('ENABLED')
 %>
 
 <div class="nav-item hidden-mobile">
@@ -46,7 +47,10 @@ should_show_order_history = should_redirect_to_order_history_microfrontend() and
       % else:
           <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
       % endif
-
+      % if show_gamification:
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('gamma_dashboard:gamma-dashboard')}" role="menuitem">${_("Performance")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('gamma_dashboard:gamma-leaderboard')}" role="menuitem">${_("Leaderboard")}</a></div>
+      % endif
       <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
       <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
       % if should_show_order_history:


### PR DESCRIPTION
## Description

Added gamification link for Legacy pages.

## Testing instructions

1. Enable `ENABLE_RG_GAMIFICATION` feature flag.
2. Configure `GAMMA_SETTINGS_URL`.
3. Open legacy LMS/CMS page.
4. Ensure the Leaderboard, Dashboard, Gamma Settings links are displayed in the user dropdown menu in the header.

![image](https://github.com/user-attachments/assets/21cc423c-1467-4de1-b7bc-74b8fd5d6121)

![image](https://github.com/user-attachments/assets/4645672e-6a51-4590-99e3-e4ce14e94b34)