### PR TITLE
fix: archived courses not showing bottom of course content

### DIFF
--- a/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_courses.scss
+++ b/edx-platform/nau-basic/lms/static/sass/partials/lms/theme/_courses.scss
@@ -8,7 +8,7 @@
     border-radius: 4px;
 }
 
-// Compact presentation of Course Messages so they don't offerflow the container and hide activities controls
+// Compact presentation of Course Messages so they don't overflow the container and hide activities controls
 .page-banner {
     .alert {
         padding-top: 10px;
@@ -20,4 +20,13 @@
     .user-messages {
         padding-top: 5px;
     }
+}
+
+// When a page-banner is present inside an xblock iframe, the banner pushes all content
+// down by its own height (~43px). The iFrameResizer measures scrollHeight before or
+// without accounting for this shift, so the iframe ends up too short and clips the
+// bottom of the activity content. Adding padding-bottom equal to the banner height
+// pre-reserves that space, ensuring iFrameResizer reports a height that fits everything.
+body:has(.page-banner) .content-wrapper.main-container {
+    padding-bottom: 60px !important;
 }

--- a/edx-platform/nau-basic/lms/templates/page_banner.html
+++ b/edx-platform/nau-basic/lms/templates/page_banner.html
@@ -24,13 +24,17 @@ if site_status_message:
 
 % if banner_messages:
     <div class="page-banner">
-        <div class="user-messages">
-            % for message in banner_messages:
-                <div class="alert ${message.css_class}" role="alert">
-                    <span class="icon icon-alert fa ${message.icon_class}" aria-hidden="true"></span>
-                    ${HTML(message.message_html)}
-                </div>
-            % endfor
+        <div class="user-messages" role="complementary" aria-label="messages">
+            <ul class="user-messages-ul">
+                % for message in banner_messages:
+                    <li>
+                        <div class="alert ${message.css_class}" role="alert">
+                            <span class="icon icon-alert fa ${message.icon_class}" aria-hidden="true"></span>
+                            ${HTML(message.message_html)}
+                        </div>
+                    </li>
+                % endfor
+            </ul>
         </div>
     </div>
 % endif


### PR DESCRIPTION
Correct overflow comment and enhance user messages structure in page banner. When the course is archived the not platform administrator couldn't see the last bottom of activity buttons.

fccn/nau-technical#882